### PR TITLE
feat(xtends): introduce `ignore` strategy.

### DIFF
--- a/packages/topoconfig/extends/README.md
+++ b/packages/topoconfig/extends/README.md
@@ -20,8 +20,14 @@ const tsconfig = await populate('tsconfig.json', {
     'compilerOptions.paths': 'merge',
     'compilerOptions.typeRoots': 'merge'
   },
-  vmap({value, prefix}) {
-    
+  vmap({value, cwd, root, prefix, key}) {
+    if (cwd !== root && (
+      prefix === 'compilerOptions.outDir' ||
+      prefix.startsWith('compilerOptions.typeRoots.') ||
+      /^compilerOptions\.paths\.[^.]+\./.test(prefix))
+    ) {
+      return path.join(path.relative(root, cwd), value)
+    }
     return value
   }
 })
@@ -141,15 +147,16 @@ const config = {
 ```
 
 You can specify how to process config fields obtained from different sources.
-There are three strategies: `populate`, `merge` and `override`. The last one is applied by default.
+There are just four strategies: `populate`, `ignore`, `merge` and `override`. The last one is applied by default.
 ```ts
 {
   foo: 'merge',
   bar: 'override',
   baz: 'merge',
   'baz.qux': 'merge',
+  cwd: 'ignore',       // do not capture the `cwd` field from the source
   extends: 'populate',
-  preset: 'populate', // now both `preset` and `extends` fields will be populated
+  preset: 'populate',  // now both `preset` and `extends` fields will be populated
 }
 ```
 

--- a/packages/topoconfig/extends/src/main/ts/extend.ts
+++ b/packages/topoconfig/extends/src/main/ts/extend.ts
@@ -20,7 +20,9 @@ export const extend = (opts: TExtendOpts) => {
 }
 
 export const extendArray = ({result, sources, prefix, rules}: TExtendCtx & {result: Array<any>}) => {
-  if (getRule(prefix, rules) === TStrategy.MERGE) {
+  const rule = getRule(prefix, rules)
+  if (rule === TStrategy.IGNORE) return result
+  if (rule === TStrategy.MERGE) {
     result.push(...sources.flat(1))
   } else {
     result.length = 0
@@ -36,6 +38,8 @@ export const extendObject = ({result, sources, prefix, rules, index}: TExtendCtx
       const p = `${prefix ? prefix + '.' : ''}${key as string}`
       const rule = getRule(p, rules)
       const value = source[key as string]
+
+      if (rule === TStrategy.IGNORE) continue
 
       result[key] = isObject(value) && rule === TStrategy.MERGE
         ? extend({

--- a/packages/topoconfig/extends/src/main/ts/interface.ts
+++ b/packages/topoconfig/extends/src/main/ts/interface.ts
@@ -49,7 +49,8 @@ export type TVmap =     (ctx: TVmapCtx) => any
 export enum TStrategy {
   OVERRIDE =  'override',
   MERGE =     'merge',
-  POPULATE =  'populate'
+  POPULATE =  'populate',
+  IGNORE =    'ignore'
 }
 
 export type TRules = Record<string, TStrategy | `${TStrategy}`>

--- a/packages/topoconfig/extends/src/main/ts/prepare.ts
+++ b/packages/topoconfig/extends/src/main/ts/prepare.ts
@@ -10,14 +10,14 @@ export const vmap = _vmap
 
 export const _clone = <T = any>({
   value,
+  id,
+  cwd =       process.cwd(),
+  root =      cwd,
+  resource =  value,
   memo =      new Map(),
   seed =      getSeed(value),
   vmap =      _vmap,
-  prefix =    '',
-  resource =  value,
-  cwd =       process.cwd(),
-  root =      cwd,
-  id
+  prefix =    ''
 }: TPrepareCtx<T>): T => seed
   ? getProps(value).reduce((m: any, k) => {
     const p = `${prefix}${k.toString()}`

--- a/packages/topoconfig/extends/src/test/ts/extend.test.ts
+++ b/packages/topoconfig/extends/src/test/ts/extend.test.ts
@@ -92,7 +92,32 @@ describe('extend', () => {
       [
         {foo: 'bar'}, {baz: 'qux'}
       ]
-    ]
+    ],
+    [
+      'recognizes `ignore` strategy',
+      {
+        sources: [
+          {a: {b: {foo: 'foo'}}},
+          {a: {b: {bar: 'bar'}, c: 'c'}, d: 'd'},
+          {a: {b: {baz: 'baz'}, c: 'C'}, d: 'D'},
+        ],
+        rules: {
+          a: 'merge',
+          'a.b': 'merge',
+          d: 'ignore'
+        }
+      },
+      {
+        a: {
+          b: {
+            foo: 'foo',
+            bar: 'bar',
+            baz: 'baz'
+          },
+          c: 'C'
+        }
+      }
+    ],
   ];
 
   cases.forEach(([name, input, expected]) => {


### PR DESCRIPTION
```js
[
  'recognizes `ignore` strategy',
  {
    sources: [
      {a: {b: {foo: 'foo'}}},
      {a: {b: {bar: 'bar'}, c: 'c'}, d: 'd'},
      {a: {b: {baz: 'baz'}, c: 'C'}, d: 'D'},
    ],
    rules: {
      a: 'merge',
      'a.b': 'merge',
      d: 'ignore'
    }
  },
  {
    a: {
      b: {
        foo: 'foo',
        bar: 'bar',
        baz: 'baz'
      },
      c: 'C'
    }
  }
],
```