### PR TITLE
feat(xtends): introduce `rebase` strategy to resolve values as root-based relative paths

### DIFF
--- a/packages/topoconfig/extends/src/main/ts/extend.ts
+++ b/packages/topoconfig/extends/src/main/ts/extend.ts
@@ -1,7 +1,8 @@
 import {TRules, TStrategy, TExtendCtx, TExtendOpts} from './interface.js'
-import {getProps, getSeed, isObject} from './util.js'
+import {getProps, getSeed, isObject, match} from './util.js'
 
-const getRule = (p: string, rules: TRules) => rules[p] || rules['*'] || TStrategy.OVERRIDE
+export const getRule = (p: string, rules: TRules) =>
+  rules[Object.keys(rules).find(k => match(p, k)) as string] || rules['*'] || TStrategy.OVERRIDE
 
 export const extend = (opts: TExtendOpts) => {
   const {

--- a/packages/topoconfig/extends/src/main/ts/interface.ts
+++ b/packages/topoconfig/extends/src/main/ts/interface.ts
@@ -50,7 +50,8 @@ export enum TStrategy {
   OVERRIDE =  'override',
   MERGE =     'merge',
   POPULATE =  'populate',
-  IGNORE =    'ignore'
+  IGNORE =    'ignore',
+  REBASE =    'rebase',
 }
 
 export type TRules = Record<string, TStrategy | `${TStrategy}`>

--- a/packages/topoconfig/extends/src/main/ts/util.ts
+++ b/packages/topoconfig/extends/src/main/ts/util.ts
@@ -27,3 +27,18 @@ export const getProps = (value: any) => [
   ...(Array.isArray(value) ? Object.keys : Object.getOwnPropertyNames)(value),
   ...Object.getOwnPropertySymbols(value)
 ]
+
+export const match = (input: string, pattern: string) => {
+  if (pattern === input || pattern === '*') return true
+  if (pattern[0] === '^') return new RegExp(pattern).test(input)
+  if (pattern.includes('*') || pattern.includes('?')) {
+    return new RegExp('^' + pattern
+      .replaceAll('.', '\\.')
+      .replaceAll('?', '.')
+      .replaceAll('**', '.+')
+      .replaceAll('*', '[^.]+')
+    + '$').test(input)
+  }
+
+  return false
+}

--- a/packages/topoconfig/extends/src/test/ts/populate.test.ts
+++ b/packages/topoconfig/extends/src/test/ts/populate.test.ts
@@ -340,6 +340,21 @@ describe('populate()', () => {
         }
       }],
       JSON.parse(fs.readFileSync(path.resolve(fixtures, 'ts-issue-56436/project1/resolved.json'), 'utf8'))
+    ],
+    [
+      'applies rebase strategy',
+      ['./tsconfig.json', {
+        cwd: path.resolve(fixtures, 'ts-issue-56436/project1'),
+        rules: {
+          compilerOptions: 'merge',
+          'compilerOptions.paths': 'merge',
+          'compilerOptions.typeRoots': 'merge',
+          'compilerOptions.typeRoots.*': 'rebase',
+          'compilerOptions.outDir': 'rebase',
+          'compilerOptions.paths.*.*': 'rebase'
+        },
+      }],
+      JSON.parse(fs.readFileSync(path.resolve(fixtures, 'ts-issue-56436/project1/resolved.json'), 'utf8'))
     ]
   ];
 

--- a/packages/topoconfig/extends/src/test/ts/util.test.ts
+++ b/packages/topoconfig/extends/src/test/ts/util.test.ts
@@ -1,0 +1,28 @@
+import * as assert from 'node:assert'
+import { describe, it } from 'node:test'
+import { match } from '../../main/ts/util.ts'
+
+describe('match()', () => {
+  describe('checks strings against patterns', () => {
+    const cases: [string, string, boolean][] = [
+      ['foo', 'foo', true],
+      ['foo', 'bar', false],
+      ['foo', 'f*', true],
+      ['foo', 'b*', false],
+      ['foo', '*', true],
+      ['foo', 'f?o', true],
+      ['foo', 'f?b', false],
+      ['foo', '^foo$', true],
+      ['foo.bar.baz', 'foo.*', false],
+      ['foo.bar.baz', 'foo.**', true],
+      ['foo.bar.baz', 'foo.*.baz', true],
+      ['foo.bar.baz', 'foo.*.*', true],
+    ]
+
+    for (const [input, pattern, expected] of cases) {
+      it(`should return ${expected} for ${input} and ${pattern}`, () => {
+        assert.strictEqual(match(input, pattern), expected)
+      })
+    }
+  })
+})


### PR DESCRIPTION
```ts
const tsconfig = await populate('tsconfig.json', {
  compilerOptions:               'merge',
  'compilerOptions.paths':       'merge',
  'compilerOptions.typeRoots':   'merge',
  'compilerOptions.typeRoots.*': 'rebase',
  'compilerOptions.outDir':      'rebase',
  'compilerOptions.paths.*.*':   'rebase'
})
```